### PR TITLE
Match Expression for MySQL 5.6+ and MariaDB 10.3+ (#1056)

### DIFF
--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsEnums.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsEnums.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.EntityFrameworkCore
+{
+    public enum MySqlMatchSearchMode
+    {
+        WithQueryExpansion,
+        InNaturalLanguageMode,
+        InNaturalLanguageModeWithQueryExpansion,
+        InBooleanMode
+    }
+}

--- a/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
+++ b/src/EFCore.MySql/Extensions/MySqlDbFunctionsExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 using JetBrains.Annotations;
+using Pomelo.EntityFrameworkCore.MySql.Internal;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -517,5 +515,32 @@ namespace Microsoft.EntityFrameworkCore
 
             return false;
         }
+
+        /// <summary>
+        ///     <para>
+        ///         An implementation of the SQL MATCH operation for Full Text search.
+        ///     </para>
+        ///     <para>
+        ///         The semantics of the comparison will depend on the database configuration.
+        ///         In particular, it may be either case-sensitive or
+        ///         case-insensitive.
+        ///     </para>
+        ///     <para>
+        ///         Should be directly translated to SQL.
+        ///         This function can't be evaluated on the client.
+        ///     </para>
+        /// </summary>
+        /// <param name="_">The DbFunctions instance.</param>
+        /// <param name="matchExpression">The property of entity that is to be matched.</param>
+        /// <param name="pattern">The pattern against which Full Text search is performed</param>
+        /// <param name="searchMode">Mode in which search is performed</param>
+        /// <returns>true if there is a match.</returns>
+        /// <exception cref="InvalidOperationException">Throws when query switched to client-evaluation.</exception>
+        public static bool Match<T>(
+            [CanBeNull] this DbFunctions _,
+            [CanBeNull] T matchExpression,
+            [CanBeNull] string pattern,
+            MySqlMatchSearchMode searchMode)
+            => throw new InvalidOperationException(MySqlStrings.FunctionOnClient(nameof(Match)));
     }
 }

--- a/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
+++ b/src/EFCore.MySql/Properties/MySqlStrings.Designer.cs
@@ -124,10 +124,12 @@ namespace Pomelo.EntityFrameworkCore.MySql.Internal
                 table);
 
         /// <summary>
-        ///     The 'FreeText' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.
+        ///     The '{methodName}' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.
         /// </summary>
-        public static string FreeTextFunctionOnClient
-            => GetString("FreeTextFunctionOnClient");
+        public static string FunctionOnClient([CanBeNull] object methodName)
+            => string.Format(
+                GetString("FunctionOnClient", nameof(methodName)),
+                methodName);
 
         /// <summary>
         ///     Computed value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Computed value generation can only be used with DateTime and DateTimeOffset properties.

--- a/src/EFCore.MySql/Properties/MySqlStrings.resx
+++ b/src/EFCore.MySql/Properties/MySqlStrings.resx
@@ -219,8 +219,8 @@
   <data name="InvalidTableToIncludeInScaffolding" xml:space="preserve">
     <value>The specified table '{table}' is not valid. Specify tables using the format '[schema].[table]'.</value>
   </data>
-  <data name="FreeTextFunctionOnClient" xml:space="preserve">
-    <value>The 'FreeText' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
+  <data name="FunctionOnClient" xml:space="preserve">
+    <value>The '{methodName}' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
   </data>
   <data name="ComputedBadType" xml:space="preserve">
     <value>Computed value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Computed value generation can only be used with DateTime and DateTimeOffset properties.</value>

--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
@@ -5,7 +5,6 @@ using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using Microsoft.EntityFrameworkCore.Storage;
 using Pomelo.EntityFrameworkCore.MySql.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 

--- a/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
+++ b/src/EFCore.MySql/Query/ExpressionVisitors/Internal/MySqlQuerySqlGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -144,6 +145,36 @@ namespace Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal
             Visit(mySqlRegexpExpression.Pattern);
 
             return mySqlRegexpExpression;
+        }
+
+        public Expression VisitMySqlMatch(MySqlMatchExpression mySqlMatchExpression)
+        {
+            Check.NotNull(mySqlMatchExpression, nameof(mySqlMatchExpression));
+
+            Sql.Append("MATCH ");
+            Sql.Append("(");
+            Visit(mySqlMatchExpression.Match);
+            Sql.Append(")");
+            Sql.Append(" AGAINST ");
+            Sql.Append($"(");
+            Visit(mySqlMatchExpression.Against);
+
+            switch (mySqlMatchExpression.SearchMode)
+            {
+                case MySqlMatchSearchMode.InBooleanMode:
+                    Sql.Append(" IN BOOLEAN MODE");
+                    break;
+                case MySqlMatchSearchMode.InNaturalLanguageModeWithQueryExpansion:
+                case MySqlMatchSearchMode.WithQueryExpansion:
+                    Sql.Append(" WITH QUERY EXPANSION");
+                    break;
+                case MySqlMatchSearchMode.InNaturalLanguageMode:
+                    break;
+            }
+
+            Sql.Append(")");
+
+            return mySqlMatchExpression;
         }
 
         protected override Expression VisitSqlUnary(SqlUnaryExpression sqlUnaryExpression)

--- a/src/EFCore.MySql/Query/Expressions/Internal/MySqlMatchExpression.cs
+++ b/src/EFCore.MySql/Query/Expressions/Internal/MySqlMatchExpression.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal;
+
+namespace Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal
+{
+    public class MySqlMatchExpression : SqlExpression
+    {
+        public MySqlMatchExpression(
+            SqlExpression match,
+            SqlExpression against,
+            MySqlMatchSearchMode searchMode,
+            RelationalTypeMapping typeMapping)
+            : base(typeof(bool), typeMapping)
+        {
+            Check.NotNull(match, nameof(match));
+            Check.NotNull(against, nameof(against));
+
+            Match = match;
+            Against = against;
+            SearchMode = searchMode;
+
+        }
+
+        public virtual MySqlMatchSearchMode SearchMode { get; }
+
+        public virtual SqlExpression Match { get; }
+        public virtual SqlExpression Against { get; }
+
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return visitor is MySqlQuerySqlGenerator mySqlQuerySqlGenerator
+                ? mySqlQuerySqlGenerator.VisitMySqlMatch(this)
+                : base.Accept(visitor);
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newMatchExpression = (SqlExpression)visitor.Visit(Match);
+            var newAgainstExpression = (SqlExpression)visitor.Visit(Against);
+
+            return newMatchExpression != Match || newAgainstExpression != Against
+                ? new MySqlMatchExpression(
+                    newMatchExpression,
+                    newAgainstExpression,
+                    SearchMode,
+                    TypeMapping)
+                : this;
+        }
+
+        public override bool Equals(object obj)
+            => obj != null && ReferenceEquals(this, obj)
+            || obj is MySqlMatchExpression matchExpression && Equals(matchExpression);
+
+        private bool Equals(MySqlMatchExpression matchExpression)
+            => base.Equals(matchExpression)
+            && SearchMode == matchExpression.SearchMode
+            && Match.Equals(matchExpression.Match)
+            && Against.Equals(matchExpression.Against);
+
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), SearchMode, Match, Against);
+
+        public override void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Append("MATCH ");
+            expressionPrinter.Append($"({expressionPrinter.Visit(Match)})");
+            expressionPrinter.Append(" AGAINST ");
+            expressionPrinter.Append($"({expressionPrinter.Visit(Against)}");
+
+            switch (SearchMode)
+            {
+                case MySqlMatchSearchMode.InBooleanMode:
+                    expressionPrinter.Append(" IN BOOLEAN MODE");
+                    break;
+                case MySqlMatchSearchMode.InNaturalLanguageModeWithQueryExpansion:
+                case MySqlMatchSearchMode.WithQueryExpansion:
+                    expressionPrinter.Append(" WITH QUERY EXPANSION");
+                    break;
+                case MySqlMatchSearchMode.InNaturalLanguageMode:
+                    break;
+            }
+
+            expressionPrinter.Append(")");
+        }
+    }
+}

--- a/src/EFCore.MySql/Query/Internal/MySqlStringMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlStringMethodTranslator.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Pomelo.EntityFrameworkCore.MySql.Query.Expressions.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Internal;
 
 namespace Pomelo.EntityFrameworkCore.MySql.Query.Internal

--- a/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/MatchQueryMySqlTest.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Pomelo.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
+using Xunit;
+
+namespace Pomelo.EntityFrameworkCore.MySql.FunctionalTests.Query
+{
+    public class MatchQueryMySqlTest : MatchQueryMySqlTestBase<MatchQueryMySqlTest.MatchQueryMySqlFixture>
+    {
+        public MatchQueryMySqlTest(MatchQueryMySqlFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [ConditionalFact]
+        public virtual void Match_In_Natural_Language_Mode()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.InNaturalLanguageMode));
+
+            Assert.Equal(3, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First')");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_In_Natural_Language_Mode_Keywords_Separated()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.InNaturalLanguageMode));
+
+            Assert.Equal(6, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First, Second')");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_In_Natural_Language_Mode_Multiple_Keywords()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First Herb", MySqlMatchSearchMode.InNaturalLanguageMode));
+
+            Assert.Equal(9, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First Herb')");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_In_Natural_Language_Mode_Multiple_Keywords_Separated()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First, Second", MySqlMatchSearchMode.InNaturalLanguageMode));
+
+            Assert.Equal(6, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First, Second')");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_In_Boolean_Mode()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First*", MySqlMatchSearchMode.InBooleanMode));
+
+            Assert.Equal(3, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First*' IN BOOLEAN MODE)");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_In_Boolean_Mode_Keywords()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First* Herb*", MySqlMatchSearchMode.InBooleanMode));
+
+            Assert.Equal(9, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First* Herb*' IN BOOLEAN MODE)");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_In_Boolean_Mode_Keyword_Excluded()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "Herb* -Second", MySqlMatchSearchMode.InBooleanMode));
+
+            Assert.Equal(6, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('Herb* -Second' IN BOOLEAN MODE)");
+        }
+
+        [ConditionalFact]
+        public virtual void Match_With_Query_Expansion()
+        {
+            using var context = CreateContext();
+            var count = context.Set<Herb>().Count(herb => EF.Functions.Match(herb.Name, "First", MySqlMatchSearchMode.WithQueryExpansion));
+
+            Assert.Equal(9, count);
+
+            AssertSql(@"SELECT COUNT(*)
+FROM `Herb` AS `h`
+WHERE MATCH (`h`.`Name`) AGAINST ('First' WITH QUERY EXPANSION)");
+        }
+
+        private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        public class MatchQueryMySqlFixture : MatchQueryMySqlFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory => MySqlTestStoreFactory.Instance;
+        }
+    }
+
+    public abstract class MatchQueryMySqlTestBase<TFixture> : QueryTestBase<TFixture>
+        where TFixture : MatchQueryMySqlTestBase<TFixture>.MatchQueryMySqlFixtureBase, new()
+    {
+        protected MatchQueryMySqlTestBase(TFixture fixture)
+            : base(fixture)
+        {
+            fixture.ListLoggerFactory.Clear();
+        }
+
+        protected virtual DbContext CreateContext() => Fixture.CreateContext();
+
+        public abstract class MatchQueryMySqlFixtureBase : SharedStoreFixtureBase<PoolableDbContext>, IQueryFixtureBase
+        {
+            protected MatchQueryMySqlFixtureBase()
+            {
+                var entitySorters = new Dictionary<Type, Func<dynamic, object>>
+                {
+                    {typeof(Herb), e => e?.Id}
+                }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+                var entityAsserters = new Dictionary<Type, Action<dynamic, dynamic>>
+                {
+                    {
+                        typeof(Herb), (e, a) =>
+                        {
+                            Assert.Equal(e == null, a == null);
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
+                        }
+                    }
+                }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+                QueryAsserter = new QueryAsserter<PoolableDbContext>(
+                    CreateContext,
+                    new MatchQueryData(),
+                    entitySorters,
+                    entityAsserters);
+            }
+
+            protected override string StoreName { get; } = "MatchQueryTest";
+            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+
+            public QueryAsserterBase QueryAsserter { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                modelBuilder.Entity<Herb>(
+                    herb =>
+                    {
+                        herb.HasData(MatchQueryData.CreateHerbs());
+                        herb.HasKey(h => h.Id);
+                        herb.HasIndex(h => h.Name).ForMySqlIsFullText();
+                    });
+            }
+
+            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            {
+                return base.AddOptions(builder).ConfigureWarnings(wcb => wcb.Throw());
+            }
+
+            public override PoolableDbContext CreateContext()
+            {
+                var context = base.CreateContext();
+                context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+                return context;
+            }
+        }
+
+        public class MatchQueryData : ISetSource
+        {
+            private readonly IReadOnlyList<Herb> _herbs;
+
+            public MatchQueryData()
+            {
+                _herbs = CreateHerbs();
+            }
+
+            public IQueryable<TEntity> Set<TEntity>() where TEntity : class
+            {
+                if (typeof(TEntity) == typeof(Herb))
+                {
+                    return (IQueryable<TEntity>)_herbs.AsQueryable();
+                }
+
+                throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
+            }
+
+            public static IReadOnlyList<Herb> CreateHerbs()
+            {
+                return new List<Herb>
+                {
+                    new Herb {Id = 1, Name = "First Herb Name 1"},
+                    new Herb {Id = 2, Name = "First Herb Name 2"},
+                    new Herb {Id = 3, Name = "First Herb Name 3"},
+                    new Herb {Id = 4, Name = "Second Herb Name 1"},
+                    new Herb {Id = 5, Name = "Second Herb Name 2"},
+                    new Herb {Id = 6, Name = "Second Herb Name 3"},
+                    new Herb {Id = 7, Name = "Third Herb Name 1"},
+                    new Herb {Id = 8, Name = "Third Herb Name 2"},
+                    new Herb {Id = 9, Name = "Third Herb Name 3"}
+                };
+            }
+        }
+
+        public class Herb
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
* Match Expression for MariaDB 10.3

* Renamed Match enum, replaced multiple calls to match expression factory with single with enum, removed StringExt extension methods to use DbFunctions later instead, removed unused files and index declaration from Northwind.sql, removed unused tests from integration tests project

* Added search mode parameter to DbFunctions.Match.
Moved Match method from StringComparison to DbFunctionsExtensions method translator and updated method infos.
Added functional tests for basic Match operations with custom context and data.

* Removed unused usings.

* Moved MySqlMatchSearchMode to separate file.
EF.Functions.Match now states that it can only be executed on relational database and throws exception on client-evaluation.
Changed MatchMethodInfo discovery mechanism.
Updated using statements according to changed enum location.

